### PR TITLE
Add `plasmid.ini` command line arg

### DIFF
--- a/src/rloopgrammar/build_model.py
+++ b/src/rloopgrammar/build_model.py
@@ -236,7 +236,7 @@ def main() -> None:
     args = parser.parse_args()
     print(args)
 
-    plasmids = read_plasmids(args.i)
+    plasmids = read_plasmids(args.ini_file)
 
     window_length = args.width
     number_of_models = args.count

--- a/src/rloopgrammar/build_model.py
+++ b/src/rloopgrammar/build_model.py
@@ -219,6 +219,7 @@ def build_model(mp: ModelParameters) -> None:
 
 parser = argparse.ArgumentParser(prog=PROGRAM_NAME, description=DESCRIPTION)
 parser.add_argument("output_folder")
+parser.add_argument('-i', '--ini_file', type=str)
 parser.add_argument("-c", "--count", type=int, default=10)
 parser.add_argument("-p", "--paddings", type=int, nargs="+", default=[13])
 parser.add_argument("-k", "--width", type=int, default=4)
@@ -235,7 +236,7 @@ def main() -> None:
     args = parser.parse_args()
     print(args)
 
-    plasmids = read_plasmids()
+    plasmids = read_plasmids(args.i)
 
     window_length = args.width
     number_of_models = args.count

--- a/src/rloopgrammar/config_reader.py
+++ b/src/rloopgrammar/config_reader.py
@@ -11,9 +11,9 @@ class Plasmid:
     bed_file: str
 
 
-def read_plasmids():
+def read_plasmids(ini_filepath):
     config = configparser.ConfigParser()
-    config.read("plasmids.ini")
+    config.read(ini_filepath)
 
     plasmids = []
     plasmid_names = config.sections()


### PR DESCRIPTION
Hi all, when trying to build a model on my own data I was confused at first on what to do with the `plasmids.ini` file I made for my various sequences. I had to read the code to figure out that this path is specified in `config_reader.py`. I think it might improve the usability to make this a command line argument instead. 

I made a few small changes that should do this as an example to what I am thinking, I haven't gotten the model running yet so it is not tested start to finish. 

Thanks!

-Ethan