### PR TITLE
Add `plasmid.ini` command line arg and improve fasta file parsing

### DIFF
--- a/src/rloopgrammar/build_model.py
+++ b/src/rloopgrammar/build_model.py
@@ -236,7 +236,7 @@ def main() -> None:
     args = parser.parse_args()
     print(args)
 
-    plasmids = read_plasmids(args.i)
+    plasmids = read_plasmids(args.ini_file)
 
     window_length = args.width
     number_of_models = args.count

--- a/src/rloopgrammar/build_model.py
+++ b/src/rloopgrammar/build_model.py
@@ -219,6 +219,7 @@ def build_model(mp: ModelParameters) -> None:
 
 parser = argparse.ArgumentParser(prog=PROGRAM_NAME, description=DESCRIPTION)
 parser.add_argument("output_folder")
+parser.add_argument('-i', '--ini_file', type=str)
 parser.add_argument("-c", "--count", type=int, default=10)
 parser.add_argument("-p", "--paddings", type=int, nargs="+", default=[13])
 parser.add_argument("-k", "--width", type=int, default=4)
@@ -235,7 +236,7 @@ def main() -> None:
     args = parser.parse_args()
     print(args)
 
-    plasmids = read_plasmids()
+    plasmids = read_plasmids(args.i)
 
     window_length = args.width
     number_of_models = args.count

--- a/src/rloopgrammar/config_reader.py
+++ b/src/rloopgrammar/config_reader.py
@@ -11,9 +11,9 @@ class Plasmid:
     bed_file: str
 
 
-def read_plasmids():
+def read_plasmids(ini_filepath):
     config = configparser.ConfigParser()
-    config.read("plasmids.ini")
+    config.read(ini_filepath)
 
     plasmids = []
     plasmid_names = config.sections()

--- a/src/rloopgrammar/model/grammar_dict.py
+++ b/src/rloopgrammar/model/grammar_dict.py
@@ -3,6 +3,8 @@ import argparse
 import json
 import random
 
+from Bio import SeqIO
+
 import openpyxl
 from openpyxl import Workbook
 from openpyxl.cell import WriteOnlyCell
@@ -288,10 +290,7 @@ class GrammarDict:
     ):
         max_rloops = 1800
         res = dict()
-        with open(fasta_in, "r") as fin:
-            fin.readline()
-            gene_seq = fin.readline().strip().upper()
-
+        gene_seq = str(SeqIO.read(fasta_in, 'fasta').seq)
         gene_seq = gene_seq[start_idx:end_idx]
 
         with open(bed_in, "r") as fin:


### PR DESCRIPTION
Closed previous pull request to fix / add an additional change. 

1. Add a command line argument `-i` to read the `plasmid.ini` file instead of having to have it at a fixed location within the program directory
2. Use BioPython to parse fasta files. The code as currently written will break if you have a fasta file with more than two lines per record which is common.

For example 
```
>test-1
atgc
>test-2
cgta
```
will read fine but an also valid format is 
```
>test-1
at
gc
>test-2
gc
at
```
which will throw an error. Using `SeqIO` from BioPython package avoid this issue. An alternative would be to not change the code but add documentation in the readme specifying the fasta formatting required. 

Thanks!